### PR TITLE
mowing sequence swapped: now obstacle outlines before fill lines

### DIFF
--- a/src/coverage_planner.cpp
+++ b/src/coverage_planner.cpp
@@ -452,57 +452,6 @@ bool planPath(slic3r_coverage_planner::PlanPathRequest &req, slic3r_coverage_pla
         res.paths.push_back(path);
     }
 
-    for (int i = 0; i < fill_lines.size(); i++) {
-        auto &line = fill_lines[i];
-        slic3r_coverage_planner::Path path;
-        path.is_outline = false;
-        path.path.header = header;
-
-        line.remove_duplicate_points();
-
-
-        auto equally_spaced_points = line.equally_spaced_points(scale_(0.1));
-        if (equally_spaced_points.size() < 2) {
-            ROS_INFO("Skipping single dot");
-            continue;
-        }
-        ROS_INFO_STREAM("Got " << equally_spaced_points.size() << " points");
-
-        Point *lastPoint = nullptr;
-        for (auto &pt: equally_spaced_points) {
-            if (lastPoint == nullptr) {
-                lastPoint = &pt;
-                continue;
-            }
-
-            // calculate pose for "lastPoint" pointing to current point
-
-            auto dir = pt - *lastPoint;
-            double orientation = atan2(dir.y, dir.x);
-            tf2::Quaternion q(0.0, 0.0, orientation);
-
-            geometry_msgs::PoseStamped pose;
-            pose.header = header;
-            pose.pose.orientation = tf2::toMsg(q);
-            pose.pose.position.x = unscale(lastPoint->x);
-            pose.pose.position.y = unscale(lastPoint->y);
-            pose.pose.position.z = 0;
-            path.path.poses.push_back(pose);
-            lastPoint = &pt;
-        }
-
-        // finally, we add the final pose for "lastPoint" with the same orientation as the last poe
-        geometry_msgs::PoseStamped pose;
-        pose.header = header;
-        pose.pose.orientation = path.path.poses.back().pose.orientation;
-        pose.pose.position.x = unscale(lastPoint->x);
-        pose.pose.position.y = unscale(lastPoint->y);
-        pose.pose.position.z = 0;
-        path.path.poses.push_back(pose);
-
-        res.paths.push_back(path);
-    }
-
     for(auto &group:obstacle_outlines) {
         slic3r_coverage_planner::Path path;
         path.is_outline = true;
@@ -563,6 +512,57 @@ bool planPath(slic3r_coverage_planner::PlanPathRequest &req, slic3r_coverage_pla
             path.path.poses.push_back(pose);
 
         }
+        res.paths.push_back(path);
+    }
+    
+    for (int i = 0; i < fill_lines.size(); i++) {
+        auto &line = fill_lines[i];
+        slic3r_coverage_planner::Path path;
+        path.is_outline = false;
+        path.path.header = header;
+
+        line.remove_duplicate_points();
+
+
+        auto equally_spaced_points = line.equally_spaced_points(scale_(0.1));
+        if (equally_spaced_points.size() < 2) {
+            ROS_INFO("Skipping single dot");
+            continue;
+        }
+        ROS_INFO_STREAM("Got " << equally_spaced_points.size() << " points");
+
+        Point *lastPoint = nullptr;
+        for (auto &pt: equally_spaced_points) {
+            if (lastPoint == nullptr) {
+                lastPoint = &pt;
+                continue;
+            }
+
+            // calculate pose for "lastPoint" pointing to current point
+
+            auto dir = pt - *lastPoint;
+            double orientation = atan2(dir.y, dir.x);
+            tf2::Quaternion q(0.0, 0.0, orientation);
+
+            geometry_msgs::PoseStamped pose;
+            pose.header = header;
+            pose.pose.orientation = tf2::toMsg(q);
+            pose.pose.position.x = unscale(lastPoint->x);
+            pose.pose.position.y = unscale(lastPoint->y);
+            pose.pose.position.z = 0;
+            path.path.poses.push_back(pose);
+            lastPoint = &pt;
+        }
+
+        // finally, we add the final pose for "lastPoint" with the same orientation as the last poe
+        geometry_msgs::PoseStamped pose;
+        pose.header = header;
+        pose.pose.orientation = path.path.poses.back().pose.orientation;
+        pose.pose.position.x = unscale(lastPoint->x);
+        pose.pose.position.y = unscale(lastPoint->y);
+        pose.pose.position.z = 0;
+        path.path.poses.push_back(pose);
+
         res.paths.push_back(path);
     }
 


### PR DESCRIPTION
### Initial situation
mowing sequence in an area now is: area outline -> fill lines -> obstacle outlines
### Change
mowing sequence ist changed to: area outline -> obstacle outlines -> fill lines
### Reason/Improvement
I noticed that (especially in spring) when the grass is still high the mower has difficulties to do the 180 degree turns on the spot over the still unmown obstacle outline areas. It does not have enough power to push the grass sideways and gets stuck.
This can be prevented by mowing the obstacle outlines before the fill lines and this PR changes this order.
### Disadvantage
I don't see any real disadvantage, the path the mower has to go is essentially the same length only in a different order. Only potential disadvantage (not for me) I can  think of is that the mower has to drive more over unmown ground to get to the obstacles.
### Tested
I tested it with two mow areas, one with one obstacle, one with two. I used a YF Classic 500 with OpenMower edge
### Code change
Very minor: only swapped the order of the last two for-loops in function planPath()
### Remark:
This is my very first pull request. I apologise if I have done something wrong.