### PR TITLE
Restore simplified markerarray for openmower-gui

### DIFF
--- a/src/coverage_planner.cpp
+++ b/src/coverage_planner.cpp
@@ -23,72 +23,75 @@
 
 
 bool visualize_plan;
+bool true_visualize_plan;
 ros::Publisher marker_array_publisher;
+ros::Publisher simple_marker_array_publisher;
 
+std::vector<std_msgs::ColorRGBA> colors;
+
+void initColors() {
+    {
+        std_msgs::ColorRGBA color;
+        color.r = 1.0;
+        color.g = 0.0;
+        color.b = 0.0;
+        color.a = 1.0;
+        colors.push_back(color);
+    }
+    {
+        std_msgs::ColorRGBA color;
+        color.r = 0.0;
+        color.g = 1.0;
+        color.b = 0.0;
+        color.a = 1.0;
+        colors.push_back(color);
+    }
+    {
+        std_msgs::ColorRGBA color;
+        color.r = 0.0;
+        color.g = 0.0;
+        color.b = 1.0;
+        color.a = 1.0;
+        colors.push_back(color);
+    }
+    {
+        std_msgs::ColorRGBA color;
+        color.r = 1.0;
+        color.g = 1.0;
+        color.b = 0.0;
+        color.a = 1.0;
+        colors.push_back(color);
+    }
+    {
+        std_msgs::ColorRGBA color;
+        color.r = 1.0;
+        color.g = 0.0;
+        color.b = 1.0;
+        color.a = 1.0;
+        colors.push_back(color);
+    }
+    {
+        std_msgs::ColorRGBA color;
+        color.r = 0.0;
+        color.g = 1.0;
+        color.b = 1.0;
+        color.a = 1.0;
+        colors.push_back(color);
+    }
+    {
+        std_msgs::ColorRGBA color;
+        color.r = 1.0;
+        color.g = 1.0;
+        color.b = 1.0;
+        color.a = 1.0;
+        colors.push_back(color);
+    }
+}
 
 void
 createMarkers(const slic3r_coverage_planner::PlanPathRequest &planning_request,
               const slic3r_coverage_planner::PlanPathResponse &planning_result,
               visualization_msgs::MarkerArray &markerArray) {
-
-    std::vector<std_msgs::ColorRGBA> colors;
-
-    {
-        std_msgs::ColorRGBA color;
-        color.r = 1.0;
-        color.g = 0.0;
-        color.b = 0.0;
-        color.a = 1.0;
-        colors.push_back(color);
-    }
-    {
-        std_msgs::ColorRGBA color;
-        color.r = 0.0;
-        color.g = 1.0;
-        color.b = 0.0;
-        color.a = 1.0;
-        colors.push_back(color);
-    }
-    {
-        std_msgs::ColorRGBA color;
-        color.r = 0.0;
-        color.g = 0.0;
-        color.b = 1.0;
-        color.a = 1.0;
-        colors.push_back(color);
-    }
-    {
-        std_msgs::ColorRGBA color;
-        color.r = 1.0;
-        color.g = 1.0;
-        color.b = 0.0;
-        color.a = 1.0;
-        colors.push_back(color);
-    }
-    {
-        std_msgs::ColorRGBA color;
-        color.r = 1.0;
-        color.g = 0.0;
-        color.b = 1.0;
-        color.a = 1.0;
-        colors.push_back(color);
-    }
-    {
-        std_msgs::ColorRGBA color;
-        color.r = 0.0;
-        color.g = 1.0;
-        color.b = 1.0;
-        color.a = 1.0;
-        colors.push_back(color);
-    }
-    {
-        std_msgs::ColorRGBA color;
-        color.r = 1.0;
-        color.g = 1.0;
-        color.b = 1.0;
-        color.a = 1.0;
-        colors.push_back(color);
-    }
 
     // Create markers for the input polygon
     {
@@ -183,6 +186,88 @@ createMarkers(const slic3r_coverage_planner::PlanPathRequest &planning_request,
         }
 
         // New color for a new path
+        cidx = (cidx + 1) % colors.size();
+    }
+}
+
+void createSimpleMarkers(const std::vector<Polygons> outline_groups,
+                         const std::vector<Polygons> obstacle_groups,
+                         const Polylines &fill_lines,
+                         visualization_msgs::MarkerArray &markerArray) {
+    // keep track of the color used last, so that we can use a new one for each path
+    uint32_t cidx = 0;
+
+    for (auto &group: outline_groups) {
+        for (auto &line: group) {
+            visualization_msgs::Marker marker;
+
+            marker.header.frame_id = "map";
+            marker.ns = "simple_mower_map_service_lines";
+            marker.id = static_cast<int>(markerArray.markers.size());
+            marker.frame_locked = true;
+            marker.action = visualization_msgs::Marker::ADD;
+            marker.type = visualization_msgs::Marker::LINE_STRIP;
+            marker.color = colors[cidx];
+            marker.pose.orientation.w = 1;
+            marker.scale.x = marker.scale.y = marker.scale.z = 0.02;
+            for (auto &pt: line.points) {
+                geometry_msgs::Point vpt;
+                vpt.x = unscale(pt.x);
+                vpt.y = unscale(pt.y);
+                marker.points.push_back(vpt);
+            }
+
+            markerArray.markers.push_back(marker);
+        }
+        cidx = (cidx + 1) % colors.size();
+    }
+
+    for(auto &group: obstacle_groups) {
+        for (auto &line: group) {
+            visualization_msgs::Marker marker;
+
+            marker.header.frame_id = "map";
+            marker.ns = "simple_mower_map_service_lines";
+            marker.id = static_cast<int>(markerArray.markers.size());
+            marker.frame_locked = true;
+            marker.action = visualization_msgs::Marker::ADD;
+            marker.type = visualization_msgs::Marker::LINE_STRIP;
+            marker.color = colors[cidx];
+            marker.pose.orientation.w = 1;
+            marker.scale.x = marker.scale.y = marker.scale.z = 0.02;
+            for (auto &pt: line.points) {
+                geometry_msgs::Point vpt;
+                vpt.x = unscale(pt.x);
+                vpt.y = unscale(pt.y);
+                marker.points.push_back(vpt);
+            }
+
+            markerArray.markers.push_back(marker);
+        }
+        cidx = (cidx + 1) % colors.size();
+    }
+
+    for(auto &line: fill_lines) {
+        visualization_msgs::Marker marker;
+
+        marker.header.frame_id = "map";
+        marker.ns = "simple_mower_map_service_lines";
+        marker.id = static_cast<int>(markerArray.markers.size());
+        marker.frame_locked = true;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.type = visualization_msgs::Marker::LINE_STRIP;
+        marker.color = colors[cidx];
+        marker.pose.orientation.w = 1;
+        marker.scale.x = marker.scale.y = marker.scale.z = 0.02;
+        for (auto &pt: line.points) {
+            geometry_msgs::Point vpt;
+            vpt.x = unscale(pt.x);
+            vpt.y = unscale(pt.y);
+            marker.points.push_back(vpt);
+        }
+
+        markerArray.markers.push_back(marker);
+
         cidx = (cidx + 1) % colors.size();
     }
 }
@@ -692,6 +777,22 @@ bool planPath(slic3r_coverage_planner::PlanPathRequest &req, slic3r_coverage_pla
             visualization_msgs::Marker marker;
 
             marker.header.frame_id = "map";
+            marker.ns = "simple_mower_map_service_lines";
+            marker.id = -1;
+            marker.frame_locked = true;
+            marker.action = visualization_msgs::Marker::DELETEALL;
+            arr.markers.push_back(marker);
+        }
+        createSimpleMarkers(area_outlines, ordered_obstacle_outlines, fill_lines, arr);
+        simple_marker_array_publisher.publish(arr);
+    }
+
+    if (true_visualize_plan) {
+        visualization_msgs::MarkerArray arr;
+        {
+            visualization_msgs::Marker marker;
+
+            marker.header.frame_id = "map";
             marker.ns = "mower_map_service_lines";
             marker.id = -1;
             marker.frame_locked = true;
@@ -702,22 +803,27 @@ bool planPath(slic3r_coverage_planner::PlanPathRequest &req, slic3r_coverage_pla
         marker_array_publisher.publish(arr);
     }
 
-
     return true;
 }
 
 
 int main(int argc, char **argv) {
+    initColors();
     ros::init(argc, argv, "slic3r_coverage_planner");
 
     ros::NodeHandle n;
     ros::NodeHandle paramNh("~");
 
     visualize_plan = paramNh.param("visualize_plan", true);
+    true_visualize_plan = paramNh.param("true_visualize_plan", false);
 
-    if (visualize_plan) {
+    if (true_visualize_plan) {
         marker_array_publisher = n.advertise<visualization_msgs::MarkerArray>(
-                "slic3r_coverage_planner/path_marker_array", 100, true);
+                "slic3r_coverage_planner/true_path_marker_array", 100, true);
+    }
+    if (visualize_plan) {
+        simple_marker_array_publisher = n.advertise<visualization_msgs::MarkerArray>(
+            "slic3r_coverage_planner/path_marker_array", 100, true);
     }
 
     ros::ServiceServer plan_path_srv = n.advertiseService("slic3r_coverage_planner/plan_path", planPath);


### PR DESCRIPTION
The true path can be very large, 90k+ points for one of the areas on my map. This appears to exceed a limit in the linestring renderer used in openmower-gui.

Restore the old inaccurate/smaller makerarray for openmower-gui and add a new accurate markerarray topic for use in rviz (disabled by default, can be enabled for debugging/sim).